### PR TITLE
Trigger build when dhcpd.conf file changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ on:
     paths:
     - Makefile
     - build.sh
+    - dhcpd.conf
     - ipxe.patch
     
   workflow_dispatch:


### PR DESCRIPTION
THis PR adds a trigger path to the build workflow.  The dhcpd.conf file is included into the image.  if this file changes, rebuild